### PR TITLE
Add Docker Compose and Prisma setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 **/node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,8 +1,27 @@
 # shock-now
 
-This repository contains a monorepo setup with a React frontend and a Node.js + Express backend.
+This repository contains a monorepo setup with a React frontend and a Node.js +
+Express backend.
 
 - **frontend**: React application
 - **backend**: Express server
 
 CI is configured with GitHub Actions in `.github/workflows/main.yml`.
+
+## Development with Docker Compose
+
+Run the application with PostgreSQL using Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+After the containers are up, apply Prisma migrations:
+
+```bash
+cd backend
+npx prisma migrate dev
+```
+
+This will initialize the database with the `User` table defined in
+`prisma/schema.prisma`.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/appdb

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,9 +1,31 @@
 const express = require('express');
+const { PrismaClient } = require('@prisma/client');
+
 const app = express();
+const prisma = new PrismaClient();
 const port = process.env.PORT || 3000;
+
+app.use(express.json());
 
 app.get('/', (req, res) => {
   res.send('Hello from backend');
+});
+
+app.get('/users', async (req, res) => {
+  const users = await prisma.user.findMany();
+  res.json(users);
+});
+
+app.post('/users', async (req, res) => {
+  try {
+    const { role, name, email, passwordHash } = req.body;
+    const user = await prisma.user.create({
+      data: { role, name, email, passwordHash },
+    });
+    res.json(user);
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
 });
 
 app.listen(port, () => {

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,10 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "@prisma/client": "^5.11.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.11.0"
   }
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,18 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id           Int      @id @default(autoincrement())
+  role         String
+  name         String?
+  email        String   @unique
+  passwordHash String
+  createdAt    DateTime @default(now())
+}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: appdb
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  api:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/appdb
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    volumes:
+      - ./backend:/app
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary
- add Docker Compose with Node backend and PostgreSQL
- create Dockerfile for backend
- integrate Prisma and define `User` model
- update API server with basic `/users` routes
- document how to start the stack and run migrations

## Testing
- `cd backend && npm run lint && npm run test`
- `cd frontend && npm run lint && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684b80adb4ac8328aaac54858ed7145e