### PR TITLE
Add auth endpoints

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,5 +1,8 @@
 const express = require('express');
 const { PrismaClient } = require('@prisma/client');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+require('dotenv').config();
 
 const app = express();
 const prisma = new PrismaClient();
@@ -9,6 +12,49 @@ app.use(express.json());
 
 app.get('/', (req, res) => {
   res.send('Hello from backend');
+});
+
+// Register endpoint
+app.post('/auth/register', async (req, res) => {
+  try {
+    const { email, password, role } = req.body;
+    if (!email || !password || !role) {
+      return res.status(400).json({ error: 'Missing fields' });
+    }
+    const passwordHash = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({
+      data: { email, role, passwordHash },
+    });
+    res.json({ id: user.id, email: user.email, role: user.role });
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
+});
+
+// Login endpoint
+app.post('/auth/login', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ error: 'Missing fields' });
+    }
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const valid = await bcrypt.compare(password, user.passwordHash);
+    if (!valid) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const token = jwt.sign(
+      { userId: user.id, role: user.role },
+      process.env.JWT_SECRET,
+      { expiresIn: '1h' }
+    );
+    res.json({ token });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
 });
 
 app.get('/users', async (req, res) => {

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,10 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "@prisma/client": "^5.11.0"
+    "@prisma/client": "^5.11.0",
+    "bcrypt": "^5.1.1",
+    "jsonwebtoken": "^9.0.2",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "prisma": "^5.11.0"


### PR DESCRIPTION
## Summary
- add auth packages
- implement `/auth/register` and `/auth/login` routes using bcrypt and JWT

## Testing
- `npm test`
- `npm run lint`
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684b81efca4c8328b14d6c8c731c2f30